### PR TITLE
Migrate to the library now that I at least understand stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f229761965dad3e9b11081668a6ea00f1def7aa46062321b5ec245b834f6e491"
+dependencies = [
+ "bitflags",
+ "coreaudio-sys",
+]
+
+[[package]]
 name = "coreaudio-sys"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1351,7 @@ name = "wavetablers"
 version = "0.1.0"
 dependencies = [
  "colored",
+ "coreaudio-rs",
  "coreaudio-sys",
  "plotters",
  "plotters-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ plotters = "0.3.1"
 plotters-backend = "0.3.0"
 quicli = "0.4"
 structopt = "0.2"
+coreaudio-rs="0.9.1"
 
 [dependencies.coreaudio-sys]
 version = "0.2.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
-pub extern crate coreaudio_sys as sys;
-use std::mem::size_of;
+extern crate coreaudio;
+
+use coreaudio::audio_unit::{AudioUnit, IOType, SampleFormat};
+use coreaudio::audio_unit::render_callback::{self, data};
 use structopt::StructOpt;
-use std::ptr;
-use std::mem;
-use std::os::raw::c_void;
 use std::fs;
-use sys::OSStatus;
 use util::apple_said_yes;
 use util::apple_said_no;
 
@@ -15,163 +13,80 @@ mod util;
 
 static mut FINALIZED_DATA:Vec<f64> = vec![];
 static mut SHOULD_MUTE:f32 = 0.0f32;
-static mut AUDIODATA:Vec<f32> = vec![];
-static mut AUDIODATAINDEX: usize = 0;
+
+struct Wavetable {
+    audio_data: Vec<f32>,
+    audio_data_index: usize,
+    should_mute: bool,
+    will_plot: bool
+}
+
+impl Wavetable {
+    pub fn new(audio_data: Vec<f32>, should_mute: bool, will_plot: bool) -> Wavetable {
+        Wavetable {
+            audio_data,
+            audio_data_index: 0,
+            should_mute,
+            will_plot
+        }
+    }
+}
+
+impl Iterator for Wavetable {
+    type Item = f32;
+    fn next(&mut self) -> Option<f32> {
+        let next = self.audio_data[self.audio_data_index] * (if self.should_mute { 0.0f32 } else { 0.05f32 });
+        if self.will_plot {
+            unsafe {
+                FINALIZED_DATA.push(self.audio_data[self.audio_data_index] as f64)
+            }
+        }
+        self.audio_data_index = (self.audio_data_index + 1) % self.audio_data.len();
+        Some(next)
+    }
+}
 
 // Note: 440 is A
 const FREQF: f64 = 440.0f64;
 const SAMPLE_RATE: f64 = 48_000.0f64;
 
-extern "C" fn my_input_wrapper(_in_ref_con: *mut c_void,
-    _flags: *mut sys::AudioUnitRenderActionFlags,
-    _time: *const sys::AudioTimeStamp,
-    _in_bus_number: sys::UInt32,
-    _in_number_frames: sys::UInt32,
-    _io_data: *mut sys::AudioBufferList) -> sys::OSStatus {
-    let toplot = unsafe { *(_in_ref_con.clone() as *mut bool) };
-    let d = unsafe { &mut *_io_data };
-    let channels_ptr = d.mBuffers.as_ptr() as *mut sys::AudioBuffer;
-    let channels_len = d.mNumberBuffers as usize;
-    assert!(channels_len == 2, "Not in stereo mode yet");
-    let buffers = unsafe { std::slice::from_raw_parts_mut(channels_ptr, channels_len) };
-    let buff_size = _in_number_frames as usize * channels_len;
-    let channel_data: &mut Vec<_> = &mut buffers
-        .iter()
-        .map(|buffer| buffer.mData as *mut f32)
-        .flat_map(|data_for_channel| unsafe { std::slice::from_raw_parts_mut(data_for_channel, buff_size) })
-        .collect::<Vec<_>>();
-    for i in 0..buff_size {
-        let point: f32 = unsafe { AUDIODATA[(AUDIODATAINDEX + i) % AUDIODATA.len()] } * 0.01f32;
-        for channel in 0..channels_len {
-            *channel_data[(buff_size * channel) + i] = point;
-        }
-        if toplot {
-            unsafe {
-                    FINALIZED_DATA.push(point as f64);
+fn main() -> Result<(), coreaudio::Error>{
+    let args = util::Cli::from_args();
+    let mut samples = Wavetable::new(sounds::make_sine().iter().map(|x| *x as f32).collect(), !args.nomute, args.plot);
+    //
+    // Construct an Output audio unit that delivers audio to the default output device.
+    let mut audio_unit = AudioUnit::new(IOType::DefaultOutput)?;
+
+    let stream_format = audio_unit.output_stream_format()?;
+    println!("{}", apple_said_yes(&format!("{:#?}", &stream_format)));
+
+    // For this example, our sine wave expects `f32` data.
+    assert!(SampleFormat::F32 == stream_format.sample_format);
+
+    type Args = render_callback::Args<data::NonInterleaved<f32>>;
+    audio_unit.set_render_callback(move |args| {
+        let Args { num_frames, mut data, .. } = args;
+        for i in 0..num_frames {
+            let sample = samples.next().unwrap();
+            for channel in data.channels_mut() {
+                channel[i] = sample;
             }
         }
-    }
-    unsafe { AUDIODATAINDEX = (AUDIODATAINDEX + buff_size) % AUDIODATA.len() };
-    return 0 as sys::OSStatus
-}
+        Ok(())
+    })?;
+    let res = audio_unit.start();
 
+    std::thread::sleep(std::time::Duration::from_millis(3000));
 
-fn main() {
-    let args = util::Cli::from_args();
-
-    if args.nomute {
-        unsafe {
-            SHOULD_MUTE = 1.00f32;
-        }
-    }
-    unsafe { AUDIODATA = sounds::make_sine().iter().map(|x| *x as f32).collect(); }
-    // initialize the AU
-    const MANUFACTURER_IDENTIFIER: u32 = sys::kAudioUnitManufacturer_Apple; // Apple wants everything signed
-    const AUDIO_TYPE: u32 = sys::kAudioUnitType_Output; // Indicates our AU will make sound
-    const AUDIO_SUBTYPE: u32 = sys::kAudioUnitSubType_DefaultOutput; // Indiciates it uses the default sound device
-    let desc = sys::AudioComponentDescription {
-        componentType: AUDIO_TYPE,
-        componentSubType: AUDIO_SUBTYPE,
-        componentManufacturer: MANUFACTURER_IDENTIFIER,
-        componentFlags: 0,
-        componentFlagsMask: 0
-    };
-    // set the thing up like this https://stackoverflow.com/a/36970515
-    let mut stream_desc = sys::AudioStreamBasicDescription {
-        mReserved: 0,
-        mBytesPerFrame: size_of::<f32>() as u32 * 2,
-        mBytesPerPacket: size_of::<f32>() as u32 * 2,
-        mBitsPerChannel: size_of::<f32>() as u32 * 8,
-        mFormatID: sys::kAudioFormatLinearPCM,
-        mFormatFlags: sys::kAudioFormatFlagIsFloat | sys::kAudioFormatFlagIsPacked,
-        mChannelsPerFrame: 2,
-        mFramesPerPacket: 1,
-        mSampleRate: SAMPLE_RATE
-    };
-    println!("{:#?} {:#?}", desc, stream_desc);
-
-
-    let component = unsafe { sys::AudioComponentFindNext(ptr::null_mut(), &desc as *const _) };
-    if component.is_null() {
-        println!("{}", apple_said_no(&"Couldn't find a component"));
-    } else {
-        println!("{}", apple_said_yes(&"Could find a component"));
-    }
-    let mut instance_uninit = mem::MaybeUninit::<sys::AudioUnit>::uninit();
-    let status: OSStatus = unsafe {
-        sys::AudioComponentInstanceNew(component,instance_uninit.as_mut_ptr() as *mut sys::AudioUnit)
-    };
-    if status == 0 as OSStatus {
-        println!("{}", apple_said_yes(&"We made an audio instance"));
-    } else {
-        println!("{}", apple_said_no(&String::from(format!("{}, {}", "We failed to make an audio instance", status))));
-    }
-
-    let instance = unsafe { instance_uninit.assume_init() };
-
-    let initalize: OSStatus = unsafe { sys::AudioUnitInitialize(instance) };
-    if initalize == 0 as OSStatus {
-        println!("{}", apple_said_yes(&"We initialized an audio instance"));
-    } else {
-        println!("{}", apple_said_no(&String::from(format!("{}, {}", "We failed to make an audio instance", initalize))));
-    }
-    let toplot: Box<bool> = Box::new(args.plot);
-    let mut render_callback = sys::AURenderCallbackStruct {
-        inputProc: Some(my_input_wrapper),
-        inputProcRefCon: Box::into_raw(toplot) as *mut c_void 
-    };
-
-    let render_callback_ref = &mut render_callback as *mut _ as *mut c_void;
-    let description_ref = &mut stream_desc as *mut _ as *mut c_void;
-    let try_start = unsafe {
-        sys::AudioUnitSetProperty (
-            instance,
-            sys::kAudioUnitProperty_StreamFormat,
-            1,
-            0,
-            description_ref,
-            ::std::mem::size_of::< sys::AudioStreamBasicDescription >() as u32
-        );
-
-        sys::AudioUnitSetProperty(
-            instance,
-            sys::kAudioUnitProperty_SetRenderCallback,
-            1,
-            0,
-            render_callback_ref,
-            ::std::mem::size_of::< sys::AURenderCallbackStruct >() as u32
-        );
-        sys::AudioOutputUnitStart(instance)
-    };
-
-    // Profit??
-    // Well, we set a render callback that will do the work, so not a whole lot of profit.
-    if try_start == 0 as OSStatus {
-        println!("{}: {:?}", apple_said_yes(&"Starting!"), try_start);
-        std::thread::sleep(std::time::Duration::from_millis(3000));
-    } else {
-        panic!("{}", apple_said_no(&"Shit"));
-    }
-
-    // Clean up?
-    let uninitalize: OSStatus = unsafe { sys::AudioUnitUninitialize(instance) };
-    if uninitalize == 0 as OSStatus {
-        println!("{}", apple_said_yes(&"We unmade a audio instance"));
-    } else {
-        println!("{}", apple_said_no(&String::from(format!("{}, {}", "We failed to unmake an audio instance", uninitalize))));
-    }
     if args.plot {
         // Print.
+        println!("{}", apple_said_yes("Plotting"));
         unsafe {
             console::draw_console(&FINALIZED_DATA);
         }
-        let outd: String = unsafe { 
-            (0..AUDIODATAINDEX) 
-                .map(|x| FINALIZED_DATA[x].to_string())
-                .fold(String::new(), |acc, x| {
-                   acc + "\n" + &x 
-                })
-        };
-        fs::write("mywave.csv", outd).expect("wanted to dump this");
+    } else {
+        println!("{}", apple_said_no("Skipping plotting"));
     }
+
+    res
 }


### PR DESCRIPTION
# So what have we learned

Welp, interacting with coreaudio is certainly weird, and perhaps even slightly difficult. To borrow from old code:

```rust
let desc = sys::AudioComponentDescription {
    componentType: sys::kAudioUnitType_Output,
    componentSubType: sys::kAudioUnitSubType_DefaultOutput,
    componentManufacturer: sys::kAudioUnitManufacturer_Apple,
    componentFlags: 0,
    componentFlagsMask: 0
};

let mut stream_desc = sys::AudioStreamBasicDescription {
    mReserved: 0,
    mBytesPerFrame: size_of::<f32>() as u32 * 2,
    mBytesPerPacket: size_of::<f32>() as u32 * 2,
    mBitsPerChannel: size_of::<f32>() as u32 * 8,
    mFormatID: sys::kAudioFormatLinearPCM,
    mFormatFlags: sys::kAudioFormatFlagIsFloat | sys::kAudioFormatFlagIsPacked,
    mChannelsPerFrame: 2,
    mFramesPerPacket: 1,
    mSampleRate: SAMPLE_RATE
};
```

Although this appears to setup a PCM stream with 2 channels, it doesn't. There are a lot of caveats to having it setup. 

In addition, apple will poll your callback and ask you to fill a buffer. Improper management of this buffer can lead to painful results for your ears (essentially white noise but randomized). The callback can also take a void* argument, but it is owned by caller who sets this parameter

```rust
let toplot: Box<bool> = Box::new(args.plot);
let mut render_callback = sys::AURenderCallbackStruct {
    inputProc: Some(my_input_wrapper),
    inputProcRefCon: Box::into_raw(toplot) as *mut c_void 
};
```

which makes it difficult to manage the memory in the callback. You can't use anything that implements the `Deref` trait (Box for example). This leads to the general issue around the callback which is **safety**.

Finally, there is no enforcement between [datatype and the format flag](https://github.com/Ch0ronomato/wavetablers/commit/cc104b3d1e82a0ecfefe47c8a27961d837aeacd9). This means you can send an incorrect datatype, and apple will attempt to read it that matches the flag, causing horrible sounds. 

# A positive thing
You can essentially view the `AudioBufferList` as a big array:

```rust
let channels_ptr: *mut sys::AudioBuffer  = ...;
let channels_len: usize = ...;
let buffers = unsafe { std::slice::from_raw_parts_mut(channels_ptr, channels_len) };
let buff_size = _in_number_frames as usize * channels_len;
let channel_data: &mut Vec<_> = &mut buffers
    .iter()
    .map(|buffer| buffer.mData as *mut f32)
    .flat_map(|data_for_channel| unsafe { std::slice::from_raw_parts_mut(data_for_channel, buff_size) })
    .collect::<Vec<_>>();
```

This makes processing the data really straightforward, with the indexing over `channel_data` to look like ` [ channel 1 + sample 0, channel 1 + sample 1, ... , channel 2 + sample 0, channel 2 + sample 1, ... ] `

```rust
for i in 0..buff_size {
    for channel in 0..channels_len {
        *channel_data[(buff_size * channel) + i] = sample;
    }
}
```

Anyway, lets not even worry about this anymore, use the coreaudio rust wrapper. 